### PR TITLE
#64 - Reading xmi then writing again results in broken xmi file

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -62,6 +62,20 @@ def cas_with_references_xmi(cas_with_references_path):
         return f.read()
 
 
+# CAS with non-indexed FS
+
+
+@pytest.fixture
+def cas_with_nonindexed_fs_path():
+    return os.path.join(FIXTURE_DIR, "xmi", "cas_with_nonindexed_fs.xmi")
+
+
+@pytest.fixture
+def cas_with_nonindexed_fs_xmi(cas_with_nonindexed_fs_path):
+    with open(cas_with_nonindexed_fs_path, "r") as f:
+        return f.read()
+
+
 # Small type system
 
 

--- a/tests/test_files/xmi/cas_with_nonindexed_fs.xmi
+++ b/tests/test_files/xmi/cas_with_nonindexed_fs.xmi
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?><xmi:XMI xmlns:pos="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos.ecore" xmlns:tcas="http:///uima/tcas.ecore" xmlns:xmi="http://www.omg.org/XMI" xmlns:cas="http:///uima/cas.ecore" xmlns:tweet="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/tweet.ecore" xmlns:morph="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/morph.ecore" xmlns:dependency="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency.ecore" xmlns:type5="http:///de/tudarmstadt/ukp/dkpro/core/api/semantics/type.ecore" xmlns:type7="http:///de/tudarmstadt/ukp/dkpro/core/api/transform/type.ecore" xmlns:heideltime="http:///de/unihd/dbs/uima/types/heideltime.ecore" xmlns:type6="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type.ecore" xmlns:type2="http:///de/tudarmstadt/ukp/dkpro/core/api/metadata/type.ecore" xmlns:type3="http:///de/tudarmstadt/ukp/dkpro/core/api/ner/type.ecore" xmlns:type4="http:///de/tudarmstadt/ukp/dkpro/core/api/segmentation/type.ecore" xmlns:type="http:///de/tudarmstadt/ukp/dkpro/core/api/coref/type.ecore" xmlns:constituent="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent.ecore" xmlns:chunk="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/chunk.ecore" xmi:version="2.0">
+  <cas:NULL xmi:id="0"/>
+  <type2:TagsetDescription xmi:id="2" sofa="1" begin="0" end="684" tags="1459 1461 1463"/>
+  <type2:TagDescription xmi:id="1459" name="&lt;+ADJ&gt;"/>
+  <type2:TagDescription xmi:id="1461" name="&lt;+ADV&gt;"/>
+  <type2:TagDescription xmi:id="1463" name="&lt;+ART&gt;"/>
+  <cas:Sofa xmi:id="1" sofaNum="1" sofaID="_InitialView" mimeType="text" sofaString="Test"/>
+  <cas:View sofa="1" members="2"/>
+</xmi:XMI>

--- a/tests/test_xmi.py
+++ b/tests/test_xmi.py
@@ -14,6 +14,7 @@ FIXTURES = [
     (pytest.lazy_fixture("cas_with_inheritance_xmi"), pytest.lazy_fixture("typesystem_with_inheritance_xml")),
     (pytest.lazy_fixture("cas_with_string_array_xmi"), pytest.lazy_fixture("small_typesystem_xml")),
     (pytest.lazy_fixture("cas_with_references_xmi"), pytest.lazy_fixture("webanno_typesystem_xml")),
+    (pytest.lazy_fixture("cas_with_nonindexed_fs_xmi"), pytest.lazy_fixture("dkpro_typesystem_xml")),
 ]
 
 


### PR DESCRIPTION
- Instead of using select_all when serializing XMI, traverse the Cas to find all the feature structures, also indirect ones