### PR TITLE
#70 - XMI serialising throws if CAS contains reference to empty array

### DIFF
--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -160,7 +160,7 @@ class Type:
         fields = {feature.name: attr.ib(default=None) for feature in self.all_features}
         fields["type"] = attr.ib(default=self.name)
 
-        self._constructor = attr.make_class(name, fields, bases=(FeatureStructure,), slots=True, cmp=False)
+        self._constructor = attr.make_class(name, fields, bases=(FeatureStructure,), slots=True, eq=False, order=False)
 
     def __call__(self, **kwargs) -> FeatureStructure:
         """ Creates an feature structure of this type

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
 
 test_dependencies = [
     "tox",
-    "pytest",
+    "pytest>=5.2.1",
     "lxml-asserts",
     "pytest-lazy-fixture",
     "codecov",

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ EMAIL = "dkpro-core-user@googlegroups.com"
 AUTHOR = "The DKPro cassis team"
 REQUIRES_PYTHON = ">=3.5.0"
 
-install_requires=[
+install_requires = [
     "lxml",
-    "attrs",
+    "attrs>=19.3.0",
     "sortedcontainers",
     "toposort",
     "more-itertools"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -76,6 +76,20 @@ def cas_with_nonindexed_fs_xmi(cas_with_nonindexed_fs_path):
         return f.read()
 
 
+# CAS with references
+
+
+@pytest.fixture
+def cas_with_empty_array_references_path():
+    return os.path.join(FIXTURE_DIR, "xmi", "cas_with_empty_array_reference.xmi")
+
+
+@pytest.fixture
+def cas_with_empty_array_references_xmi(cas_with_empty_array_references_path):
+    with open(cas_with_empty_array_references_path, "r") as f:
+        return f.read()
+
+
 # Small type system
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -76,7 +76,7 @@ def cas_with_nonindexed_fs_xmi(cas_with_nonindexed_fs_path):
         return f.read()
 
 
-# CAS with references
+# CAS with empty array references
 
 
 @pytest.fixture

--- a/tests/test_files/xmi/cas_with_empty_array_reference.xmi
+++ b/tests/test_files/xmi/cas_with_empty_array_reference.xmi
@@ -1,0 +1,16 @@
+<xmi:XMI xmlns:xmi="http://www.omg.org/XMI" xmlns:cas="http:///uima/cas.ecore" xmlns:type="http:///de/tudarmstadt/ukp/dkpro/core/api/metadata/type.ecore" xmlns:type0="http:///de/tudarmstadt/ukp/dkpro/core/api/segmentation/type.ecore" xmi:version="2.0">
+  <cas:NULL xmi:id="0"/>
+  <type:DocumentMetaData xmi:id="2" documentTitle="test_file.txt" documentId="test_file.txt" documentUri="file:/export/repository/project/20/document/13151/source/test_file.txt" collectionId="file:/export/repository/project/20/document/13151/source/" documentBaseUri="file:/export/repository/project/20/document/13151/source/" isLastSegment="false" begin="0" end="22" sofa="1" language="x-unspecified"/>
+  <type0:Sentence xmi:id="3" begin="0" end="22" sofa="1"/>
+  <type0:Token xmi:id="4" begin="0" end="4" sofa="1"/>
+  <type0:Token xmi:id="5" begin="5" end="6" sofa="1"/>
+  <type0:Token xmi:id="6" begin="7" end="12" sofa="1"/>
+  <type0:Token xmi:id="7" begin="13" end="17" sofa="1"/>
+  <type0:Token xmi:id="8" begin="18" end="22" sofa="1"/>
+  <type:TagsetDescription xmi:id="9" layer="de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency" name="UD Universal Dependencies" input="false" begin="0" end="0" sofa="1"/>
+  <type:TagsetDescription xmi:id="10" layer="de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity" name="Named Entity tags" input="false" begin="0" end="0" sofa="1"/>
+  <type:TagsetDescription xmi:id="11" layer="de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation" name="Operation" input="false" begin="0" end="0" sofa="1"/>
+  <type:TagsetDescription xmi:id="12" layer="de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS" name="UD Universal POS tags" input="false" begin="0" end="0" sofa="1"/>
+  <cas:Sofa xmi:id="1" sofaNum="1" sofaID="_InitialView" mimeType="text" sofaString="just a short test file"/>
+  <cas:View sofa="1" members="2 3 4 5 6 7 8 9 10 11 12"/>
+</xmi:XMI>

--- a/tests/test_xmi.py
+++ b/tests/test_xmi.py
@@ -15,6 +15,7 @@ FIXTURES = [
     (pytest.lazy_fixture("cas_with_string_array_xmi"), pytest.lazy_fixture("small_typesystem_xml")),
     (pytest.lazy_fixture("cas_with_references_xmi"), pytest.lazy_fixture("webanno_typesystem_xml")),
     (pytest.lazy_fixture("cas_with_nonindexed_fs_xmi"), pytest.lazy_fixture("dkpro_typesystem_xml")),
+    (pytest.lazy_fixture("cas_with_empty_array_references_xmi"), pytest.lazy_fixture("dkpro_typesystem_xml")),
 ]
 
 


### PR DESCRIPTION
- Add None check when traversing CAS for serialising
- Add tests
- Fix deprecation warning of attrs