### PR TITLE
#67 - Creating cas without typesystem shares the default typesystem

### DIFF
--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -87,8 +87,14 @@ class View:
 class Cas:
     """A CAS object is a container for text (sofa) and annotations"""
 
-    def __init__(self, typesystem: TypeSystem = TypeSystem()):
-        self._typesystem = typesystem
+    def __init__(self, typesystem: TypeSystem = None):
+        """ Creates a CAS with the specified typesystem. If no typesystem is given, then the default one
+        is used which only contains UIMA-predefined types.
+
+        Args:
+            typesystem: The types system to use.
+        """
+        self._typesystem = typesystem if typesystem else TypeSystem()
 
         # When new attributes are added, they also need to be added in Cas::_copy. The copying
         # relies on the fact that all the members of the Cas are mutable references. It is not

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -4,8 +4,19 @@ import attr
 
 from tests.fixtures import *
 
-from cassis.cas import Cas, Sofa, View
-import cassis.typesystem
+from cassis.cas import Cas
+
+# Cas
+
+
+def test_default_typesystem_is_not_shared():
+    # https://github.com/dkpro/dkpro-cassis/issues/67
+    cas1 = Cas()
+    cas2 = Cas()
+
+    t1 = cas1.typesystem.create_type(name="test.Type")
+    t2 = cas2.typesystem.create_type(name="test.Type")
+
 
 # View
 


### PR DESCRIPTION
- Use none instead of inline construction of default parameter