### PR TITLE
#73 - Add get_covered_text method to Annotations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Selecting annotations
 
     for sentence in cas.select('cassis.Sentence'):
         for token in cas.select_covered('cassis.Token', sentence):
-            print(cas.get_covered_text(token))
+            print(token.get_covered_text())
             
             # Annotation values can be accessed as properties
             print('Token: begin={0}, end={1}, id={2}, pos={3}'.format(token.begin, token.end, token.id, token.pos)) 
@@ -204,7 +204,7 @@ as a :code:`Cas` .
         Token(begin=14, end=15)
     ])
 
-    print([cas.get_covered_text(x) for x in cas.select_all()])
+    print([x.get_covered_text() for x in cas.select_all()])
 
     # Create a new view and work on it.
     view = cas.create_view('testView')
@@ -217,7 +217,7 @@ as a :code:`Cas` .
         Token(begin=20, end=21)
     ])
 
-    print([view.get_covered_text(x) for x in view.select_all()])
+    print([x.get_covered_text() for x in view.select_all()])
 
 Development
 -----------

--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -12,6 +12,8 @@ from sortedcontainers import SortedList, SortedKeyList
 
 from cassis.typesystem import FeatureStructure, TypeSystem
 
+import deprecation
+
 _validator_optional_string = validators.optional(validators.instance_of(str))
 
 
@@ -192,6 +194,7 @@ class Cas:
         for annotation in annotations:
             self.add_annotation(annotation)
 
+    @deprecation.deprecated()
     def get_covered_text(self, annotation: FeatureStructure) -> str:
         """ Gets the text that is covered by `annotation`.
 

--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -178,7 +178,7 @@ class Cas:
         """
         annotation.xmiID = self._get_next_xmi_id()
         if hasattr(annotation, "sofa"):
-            annotation.sofa = self.get_sofa().xmiID
+            annotation.sofa = self.get_sofa()
 
         self._current_view.add_annotation_to_index(annotation)
 

--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -125,6 +125,18 @@ class FeatureStructure:
     def __eq__(self, other):
         return self.__slots__ == other.__slots__
 
+    def get_covered_text(self):
+        """ Gets the text that is covered by this feature structure iff it is associated with a sofa and has a begin/end.
+
+        Returns:
+            The text covered by the annotation
+
+        """
+        if hasattr(self, "sofa") and hasattr(self, "begin") and hasattr(self, "end"):
+            return self.sofa.sofaString[self.begin : self.end]
+        else:
+            raise NotImplementedError()
+
 
 @attr.s(slots=True)
 class Feature:

--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -125,7 +125,7 @@ class FeatureStructure:
     def __eq__(self, other):
         return self.__slots__ == other.__slots__
 
-    def get_covered_text(self):
+    def get_covered_text(self) -> str:
         """ Gets the text that is covered by this feature structure iff it is associated with a sofa and has a begin/end.
 
         Returns:

--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -363,7 +363,9 @@ class CasXmiSerializer:
                 for e in value:
                     child = etree.SubElement(elem, feature_name)
                     child.text = e
-            elif feature_name == "sofa" or cas.typesystem.is_primitive(feature.rangeTypeName):
+            elif feature_name == "sofa":
+                elem.attrib[feature_name] = str(value.xmiID)
+            elif cas.typesystem.is_primitive(feature.rangeTypeName):
                 elem.attrib[feature_name] = str(value)
             elif cas.typesystem.is_collection(feature.rangeTypeName):
                 elements = " ".join(str(e.xmiID) for e in value)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ install_requires = [
     "attrs>=19.3.0",
     "sortedcontainers",
     "toposort",
-    "more-itertools"
+    "more-itertools",
+    "deprecation"
 ]
 
 test_dependencies = [

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -210,28 +210,43 @@ def inception_typesystem_xml(inception_typesystem_path):
 def tokens(small_typesystem_xml):
     typesystem = load_typesystem(small_typesystem_xml)
 
+    cas = Cas(typesystem)
+    cas.sofa_string = "Joe waited for the train . The train was late ."
+
     TokenType = typesystem.get_type("cassis.Token")
-    return [
-        TokenType(xmiID=3, sofa=1, begin=0, end=3, id="0", pos="NNP"),
-        TokenType(xmiID=4, sofa=1, begin=4, end=10, id="1", pos="VBD"),
-        TokenType(xmiID=5, sofa=1, begin=11, end=14, id="2", pos="IN"),
-        TokenType(xmiID=6, sofa=1, begin=15, end=18, id="3", pos="DT"),
-        TokenType(xmiID=7, sofa=1, begin=19, end=24, id="4", pos="NN"),
-        TokenType(xmiID=8, sofa=1, begin=25, end=26, id="5", pos="."),
-        TokenType(xmiID=9, sofa=1, begin=27, end=30, id="6", pos="DT"),
-        TokenType(xmiID=10, sofa=1, begin=31, end=36, id="7", pos="NN"),
-        TokenType(xmiID=11, sofa=1, begin=37, end=40, id="8", pos="VBD"),
-        TokenType(xmiID=12, sofa=1, begin=41, end=45, id="9", pos="JJ"),
-        TokenType(xmiID=13, sofa=1, begin=46, end=47, id="10", pos="."),
+    tokens = [
+        TokenType(begin=0, end=3, id="0", pos="NNP"),
+        TokenType(begin=4, end=10, id="1", pos="VBD"),
+        TokenType(begin=11, end=14, id="2", pos="IN"),
+        TokenType(begin=15, end=18, id="3", pos="DT"),
+        TokenType(begin=19, end=24, id="4", pos="NN"),
+        TokenType(begin=25, end=26, id="5", pos="."),
+        TokenType(begin=27, end=30, id="6", pos="DT"),
+        TokenType(begin=31, end=36, id="7", pos="NN"),
+        TokenType(begin=37, end=40, id="8", pos="VBD"),
+        TokenType(begin=41, end=45, id="9", pos="JJ"),
+        TokenType(begin=46, end=47, id="10", pos="."),
     ]
 
+    for token in tokens:
+        cas.add_annotation(token)
+
+    return tokens
 
 @pytest.fixture
 def sentences(small_typesystem_xml):
     typesystem = load_typesystem(small_typesystem_xml)
     SentenceType = typesystem.get_type("cassis.Sentence")
 
-    return [
-        SentenceType(xmiID=14, sofa=1, begin=0, end=26, id="0"),
-        SentenceType(xmiID=15, sofa=1, begin=27, end=47, id="1"),
+    cas = Cas(typesystem)
+    cas.sofa_string = "Joe waited for the train . The train was late ."
+
+    sentences = [
+        SentenceType(begin=0, end=26, id="0"),
+        SentenceType(begin=27, end=47, id="1"),
     ]
+
+    for sentence in sentences:
+        cas.add_annotation(sentence)
+
+    return sentences

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -153,11 +153,31 @@ def test_get_covered_text_tokens(tokens):
     assert actual_text == expected_text
 
 
+def test_FeatureStructure_get_covered_text_tokens(tokens):
+    cas = Cas()
+    cas.sofa_string = "Joe waited for the train . The train was late ."
+
+    actual_text = [token.get_covered_text() for token in tokens]
+
+    expected_text = ["Joe", "waited", "for", "the", "train", ".", "The", "train", "was", "late", "."]
+    assert actual_text == expected_text
+
+
 def test_get_covered_text_sentences(sentences):
     cas = Cas()
     cas.sofa_string = "Joe waited for the train . The train was late ."
 
     actual_text = [cas.get_covered_text(sentence) for sentence in sentences]
+
+    expected_text = ["Joe waited for the train .", "The train was late ."]
+    assert actual_text == expected_text
+
+
+def test_FeatureStructure_get_covered_text_sentences(sentences):
+    cas = Cas()
+    cas.sofa_string = "Joe waited for the train . The train was late ."
+
+    actual_text = [sentence.get_covered_text() for sentence in sentences]
 
     expected_text = ["Joe waited for the train .", "The train was late ."]
     assert actual_text == expected_text


### PR DESCRIPTION
- Make annotation.sofa an actual reference to the sofa instead of just storing its XMI ID
- During serialization, fetch the XMI ID and write it out