### PR TITLE
#88 - Keyerror if supertype has no namespace

### DIFF
--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -563,12 +563,14 @@ class TypeSystemDeserializer:
         context = etree.iterparse(source, events=("end",), tag=("{*}typeDescription",))
         for event, elem in context:
             type_name = self._get_elem_as_str(elem.find("{*}name"))
+            description = self._get_elem_as_str(elem.find("{*}description"))
+            supertypeName = self._get_elem_as_str(elem.find("{*}supertypeName"))
 
             if "." not in type_name:
                 type_name = "uima.noNamespace." + type_name
 
-            description = self._get_elem_as_str(elem.find("{*}description"))
-            supertypeName = self._get_elem_as_str(elem.find("{*}supertypeName"))
+            if "." not in supertypeName:
+                supertypeName = "uima.noNamespace." + supertypeName
 
             types[type_name] = Type(name=type_name, supertypeName=supertypeName, description=description)
             type_dependencies[type_name].add(supertypeName)
@@ -700,8 +702,11 @@ class TypeSystemSerializer:
         description = etree.SubElement(typeDescription, "description")
         description.text = type_.description
 
-        supertypeName = etree.SubElement(typeDescription, "supertypeName")
-        supertypeName.text = type_.supertypeName
+        supertype_name_node = etree.SubElement(typeDescription, "supertypeName")
+        supertype_name = type_.supertypeName
+        if supertype_name.startswith("uima.noNamespace."):
+            supertype_name = supertype_name.replace("uima.noNamespace.", "")
+        supertype_name_node.text = supertype_name
 
         # Only create the `feature` element if there is at least one feature
         feature_list = list(type_.features)

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -177,7 +177,7 @@ def test_get_covered_text_tokens(tokens):
     cas = Cas()
     cas.sofa_string = "Joe waited for the train . The train was late ."
 
-    actual_text = [cas.get_covered_text(token) for token in tokens]
+    actual_text = [token.get_covered_text() for token in tokens]
 
     expected_text = ["Joe", "waited", "for", "the", "train", ".", "The", "train", "was", "late", "."]
     assert actual_text == expected_text
@@ -197,7 +197,7 @@ def test_get_covered_text_sentences(sentences):
     cas = Cas()
     cas.sofa_string = "Joe waited for the train . The train was late ."
 
-    actual_text = [cas.get_covered_text(sentence) for sentence in sentences]
+    actual_text = [sentence.get_covered_text() for sentence in sentences]
 
     expected_text = ["Joe waited for the train .", "The train was late ."]
     assert actual_text == expected_text

--- a/tests/test_files/typesystems/typesystem_has_types_with_no_namespace.xml
+++ b/tests/test_files/typesystems/typesystem_has_types_with_no_namespace.xml
@@ -32,5 +32,11 @@
                 </featureDescription>
             </features>
         </typeDescription>
+        <typeDescription>
+            <name>ChildOfArtifactID</name>
+            <supertypeName>ArtifactID</supertypeName>
+            <description/>
+
+        </typeDescription>
     </types>
 </typeSystemDescription>


### PR DESCRIPTION
- Add prefix to supertype in case of missing namespace
- Remove prefix on save
- Fix covered_text deprecation warning