### PR TITLE
#126 - select does not return instances of all (transitive) subtypes of the type queried for

### DIFF
--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -312,8 +312,7 @@ class Cas:
     def _get_feature_structures(self, type_name) -> Iterator[FeatureStructure]:
         """ Returns an iterator over all feature structures of type `type_name` and child types. """
         t = self._typesystem.get_type(type_name)
-        types = {c.name for c in t.children}
-        types.add(type_name)
+        types = {c.name for c in t.descendants}
 
         for name in types:
             yield from self._current_view.type_index[name]
@@ -324,8 +323,7 @@ class Cas:
          you should always check bound in the calling method.
          """
         t = self._typesystem.get_type(type_name)
-        types = {c.name for c in t.children}
-        types.add(type_name)
+        types = {c.name for c in t.descendants}
 
         for name in types:
             annotations = self._current_view.type_index[name]

--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -326,6 +326,18 @@ class Type:
     def children(self) -> Iterator["Type"]:
         yield from self._children.values()
 
+    @property
+    def descendants(self) -> Iterator["Type"]:
+        """
+        Returns an iterator of the type and any descendant types (subtypes).
+        """
+        if self._children:
+            for child in self._children.values():
+                yield self
+                yield from child.descendants
+        else:
+            yield self
+
 
 class TypeSystem:
     def __init__(self, add_document_annotation_type: bool = True):

--- a/tests/test_typesystem.py
+++ b/tests/test_typesystem.py
@@ -110,6 +110,26 @@ def test_type_can_create_instance_with_deeply_inherited_fields(typesystem_with_i
     assert "childFeature" in t._inherited_features
 
 
+def test_type_can_retrieve_children(typesystem_with_inheritance_xml):
+    typesystem = load_typesystem(typesystem_with_inheritance_xml)
+
+    t = typesystem.get_type("cassis.Child")
+
+    children = [item.name for item in t.children]
+
+    assert children == ['cassis.GrandChild']
+
+
+def test_type_can_retrieve_descendants(typesystem_with_inheritance_xml):
+    typesystem = load_typesystem(typesystem_with_inheritance_xml)
+
+    t = typesystem.get_type("cassis.Child")
+
+    descendants = [item.name for item in t.descendants]
+
+    assert descendants == ['cassis.Child', 'cassis.GrandChild', 'cassis.GrandGrandChild', 'cassis.GrandGrandGrandChild']
+
+
 def test_type_inherits_from_annotation_base():
     typesystem = TypeSystem()
     test_type = typesystem.create_type(name="test.Type", supertypeName="uima.cas.AnnotationBase")


### PR DESCRIPTION
- added type.descendants property
- use this property instead of the children property in _get_feature_structures and _get_feature_structures_in_range
- added unit test for descdentants