### PR TITLE
resolve reference to sofa for nested FeatureStructure

### DIFF
--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -210,6 +210,22 @@ class Cas:
         annotation.xmiID = next_id
         if hasattr(annotation, "sofa"):
             annotation.sofa = self.get_sofa()
+            
+            #resolve reference to sofa for FeatureStructure with nested FeatureStructure
+            t=self._typesystem.get_type( annotation.type )
+
+            for feature in t.all_features:
+                feature_name = feature.name
+                value=getattr(annotation, feature_name)
+                if value is None:
+                    continue
+                if self._typesystem.is_collection(annotation.type, feature ):
+                    for item in value:
+                        if hasattr( item, 'sofa' ):
+                            item.sofa=self.get_sofa()
+                else:
+                    if hasattr( value, 'sofa' ):
+                        value.sofa=self.get_sofa()
 
         self._current_view.add_annotation_to_index(annotation)
 


### PR DESCRIPTION
For the following typesystem and xml:

https://drive.google.com/drive/folders/1GqWanaAB9Duj8orYLTDtfNILv3OmZD24?usp=sharing


```
with open('typesystem.xml', 'rb') as f:
    typesystem = load_typesystem(f)

cas = load_cas_from_xmi(open('simple.xml', 'rb'), typesystem=typesystem)

cas.to_xmi( path="../output_dir/simple_out.xml" )  
```
I get the following error after loading to cas, and then creating an xmi representation:

```
...
xmi.py in _serialize_feature_structure(self, cas, root, fs)
    365                     child.text = e
    366             elif feature_name == "sofa":
--> 367                 elem.attrib[feature_name] = str(value.xmiID)
    368             elif ts.is_primitive(feature.rangeTypeName):
    369                 elem.attrib[feature_name] = str(value)

AttributeError: 'int' object has no attribute 'xmiID'

```

This is because references to the Sofa object for nested FeatureStructure is not done correct. 
(<html:TagAttribute xmi:id="25" sofa="1" begin="11" end="28" name="class" value=".nice"/> in the example)

The bug is fixed with this pull request. 
(The fix, however, causes a problem when an annotation is added to a cas that is not part of the typesystem. However, this feature does not seem to be particularly interesting)

