### PR TITLE
 #157 - String in multipleReferencesAllowed is incorrectly parsed

### DIFF
--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -831,7 +831,13 @@ class TypeSystemDeserializer:
 
     def _get_elem_as_bool(self, elem: etree.Element) -> Optional[bool]:
         if elem is not None:
-            return bool(elem.text)
+            text = elem.text
+            if text == "true":
+                return True
+            elif text == "false":
+                return False
+            else:
+                raise ValueError("Cannot parse boolean: " + str(text))
         else:
             return None
 

--- a/tests/test_files/typesystems/small_typesystem.xml
+++ b/tests/test_files/typesystems/small_typesystem.xml
@@ -15,6 +15,7 @@
                     <name>pos</name>
                     <description/>
                     <rangeTypeName>uima.cas.String</rangeTypeName>
+                    <multipleReferencesAllowed>true</multipleReferencesAllowed>
                 </featureDescription>
             </features>
         </typeDescription>
@@ -27,6 +28,7 @@
                     <name>id</name>
                     <description/>
                     <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                    <multipleReferencesAllowed>false</multipleReferencesAllowed>
                 </featureDescription>
             </features>
         </typeDescription>

--- a/tests/test_typesystem.py
+++ b/tests/test_typesystem.py
@@ -367,6 +367,7 @@ def test_deserializing_small_typesystem(small_typesystem_xml):
     token_pos_feature = token_type.get_feature("pos")
     assert token_pos_feature.name == "pos"
     assert token_pos_feature.rangeTypeName == "uima.cas.String"
+    assert token_pos_feature.multipleReferencesAllowed is True
 
     # Assert sentence type
     sentence_type = typesystem.get_type("cassis.Sentence")
@@ -376,6 +377,7 @@ def test_deserializing_small_typesystem(small_typesystem_xml):
     sentence_type_id_feature = sentence_type.get_feature("id")
     assert sentence_type_id_feature.name == "id"
     assert sentence_type_id_feature.rangeTypeName == "uima.cas.Integer"
+    assert sentence_type_id_feature.multipleReferencesAllowed is False
 
 
 # Serializing


### PR DESCRIPTION
 - Use real logic to parse bools