### PR TITLE
#174 - FSes that are only transitively referenced cannot be serialized

### DIFF
--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -339,6 +339,11 @@ class CasXmiSerializer:
 
         self._serialize_cas_null(root)
 
+        # Generate XMI ids for unset ones
+        for fs in cas._find_all_fs():
+            if fs.xmiID is None:
+                fs.xmiID = cas._get_next_xmi_id()
+
         # Find all fs, even the ones that are not directly added to a sofa
         for fs in sorted(cas._find_all_fs(), key=lambda a: a.xmiID):
             self._serialize_feature_structure(cas, root, fs)

--- a/tests/test_xmi.py
+++ b/tests/test_xmi.py
@@ -221,6 +221,22 @@ def test_serializing_xmi_namespaces_with_same_prefixes_but_different_urls_are_di
     assert len(root.xpath("//test0:Bar", namespaces=root.nsmap)) == 2
 
 
+def test_serializing_with_unset_xmi_ids_works():
+    typesystem = TypeSystem()
+    cas = Cas(typesystem)
+    FooType = typesystem.create_type("foo.test.Foo")
+    typesystem.add_feature(FooType, "bar", "bar.test.Bar")
+    BarType = typesystem.create_type("bar.test.Bar")
+
+    # Check that two annotations of the same type get the same namespace
+    foo = FooType()
+    cas.add_annotation(foo)
+    foo.bar = BarType()
+
+    # assert no error
+    cas.to_xmi(pretty_print=True)
+
+
 # UIMA vs cassis offsets
 
 


### PR DESCRIPTION
- When serializing XMI, set XMI ids if None