### PR TITLE
#174 - FSes that are only transitively referenced cannot be serialized (#179)

### DIFF
--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -590,7 +590,7 @@ class Cas:
         ts = self.typesystem
         while openlist:
             fs = openlist.pop(0)
-            if generate_missing_ids:
+            if generate_missing_ids and fs.xmiID is None:
                 fs.xmiID = self._get_next_xmi_id()
             all_fs[fs.xmiID] = fs
 

--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -576,7 +576,7 @@ class Cas:
 
         return all_errors
 
-    def _find_all_fs(self) -> Iterable[FeatureStructure]:
+    def _find_all_fs(self, generate_missing_ids: bool = False) -> Iterable[FeatureStructure]:
         """This function traverses the whole CAS in order to find all directly and indirectly referenced
         feature structures. Traversing is needed as it can be that a feature structure is not added to the sofa but
         referenced by another feature structure as a feature."""
@@ -590,6 +590,8 @@ class Cas:
         ts = self.typesystem
         while openlist:
             fs = openlist.pop(0)
+            if generate_missing_ids:
+                fs.xmiID = self._get_next_xmi_id()
             all_fs[fs.xmiID] = fs
 
             t = ts.get_type(fs.type)

--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -593,7 +593,7 @@ class Cas:
 
             # We do not want to return cas:NULL here as we handle serializing it later
             if fs.xmiID == 0:
-                continue;
+                continue
 
             if fs.xmiID is None:
                 if generate_missing_ids:

--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -576,7 +576,7 @@ class Cas:
 
         return all_errors
 
-    def _find_all_fs(self, generate_missing_ids: bool = False) -> Iterable[FeatureStructure]:
+    def _find_all_fs(self, generate_missing_ids: bool = True) -> Iterable[FeatureStructure]:
         """This function traverses the whole CAS in order to find all directly and indirectly referenced
         feature structures. Traversing is needed as it can be that a feature structure is not added to the sofa but
         referenced by another feature structure as a feature."""
@@ -590,8 +590,25 @@ class Cas:
         ts = self.typesystem
         while openlist:
             fs = openlist.pop(0)
-            if generate_missing_ids and fs.xmiID is None:
-                fs.xmiID = self._get_next_xmi_id()
+
+            # We do not want to return cas:NULL here as we handle serializing it later
+            if fs.xmiID == 0:
+                continue;
+
+            if fs.xmiID is None:
+                if generate_missing_ids:
+                    fs.xmiID = self._get_next_xmi_id()
+                else:
+                    raise ValueError("FS has no ID and ID generation is disabled! {fs}".format(fs=fs))
+
+            existing_fs = all_fs.get(fs.xmiID)
+            if existing_fs is not None and existing_fs is not fs:
+                raise ValueError(
+                    "Duplicate FS id [{fsId}] used for [{fs1}] and [{fs2}]".format(
+                        fsId=fs.xmiID, fs1=existing_fs, fs2=fs
+                    )
+                )
+
             all_fs[fs.xmiID] = fs
 
             t = ts.get_type(fs.type)
@@ -623,8 +640,6 @@ class Cas:
                     if referenced_fs.xmiID not in all_fs:
                         openlist.append(referenced_fs)
 
-        # We do not want to return cas:NULL here as we handle serializing it later
-        all_fs.pop(0, None)
         yield from all_fs.values()
 
     def _get_next_xmi_id(self) -> int:

--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -343,7 +343,7 @@ class CasXmiSerializer:
         self._serialize_cas_null(root)
 
         # Find all fs, even the ones that are not directly added to a sofa
-        for fs in sorted(cas._find_all_fs(generate_missing_ids=True), key=lambda a: a.xmiID):
+        for fs in sorted(cas._find_all_fs(), key=lambda a: a.xmiID):
             self._serialize_feature_structure(cas, root, fs)
 
         for sofa in cas.sofas:

--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -342,13 +342,8 @@ class CasXmiSerializer:
 
         self._serialize_cas_null(root)
 
-        # Generate XMI ids for unset ones
-        for fs in cas._find_all_fs():
-            if fs.xmiID is None:
-                fs.xmiID = cas._get_next_xmi_id()
-
         # Find all fs, even the ones that are not directly added to a sofa
-        for fs in sorted(cas._find_all_fs(), key=lambda a: a.xmiID):
+        for fs in sorted(cas._find_all_fs(generate_missing_ids=True), key=lambda a: a.xmiID):
             self._serialize_feature_structure(cas, root, fs)
 
         for sofa in cas.sofas:

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -443,3 +443,14 @@ def test_removing_throws_if_fs_in_other_view(small_typesystem_xml, tokens, sente
 
     with pytest.raises(ValueError):
         view.remove(tokens[0])
+
+
+def test_fail_on_duplicate_fs_id(small_typesystem_xml):
+    cas = Cas(typesystem=load_typesystem(small_typesystem_xml))
+
+    TokenType = cas.typesystem.get_type("cassis.Token")
+    cas.add_annotation(TokenType(xmiID=10, begin=0, end=0))
+    cas.add_annotation(TokenType(xmiID=10, begin=10, end=10))
+
+    with pytest.raises(ValueError):
+        list(cas._find_all_fs())

--- a/tests/test_xmi.py
+++ b/tests/test_xmi.py
@@ -198,7 +198,7 @@ def test_serializing_xmi_ignores_none_features(small_xmi, small_typesystem_xml):
     typesystem = load_typesystem(small_typesystem_xml)
     cas = load_cas_from_xmi(small_xmi, typesystem=typesystem)
     TokenType = typesystem.get_type("cassis.Token")
-    cas.add(TokenType(xmiID=13, sofa=1, begin=0, end=3, id=None, pos=None))
+    cas.add(TokenType(begin=0, end=3, id=None, pos=None))
 
     actual_xml = cas.to_xmi()
 

--- a/tests/test_xmi.py
+++ b/tests/test_xmi.py
@@ -233,9 +233,13 @@ def test_serializing_with_unset_xmi_ids_works():
     BarType = typesystem.create_type("bar.test.Bar")
 
     # Check that two annotations of the same type get the same namespace
-    foo = FooType()
-    cas.add(foo)
-    foo.bar = BarType()
+    foo1 = FooType()
+    cas.add(foo1)
+    foo1.bar = BarType()
+
+    foo2 = FooType()
+    cas.add(foo2)
+    foo2.bar = BarType()
 
     # assert no error
     cas.to_xmi(pretty_print=True)


### PR DESCRIPTION
- Initial fix did only work for the first fs without xmiID, but as soon as there would be two FSes with missing ids, it broke
- Extended the test
- Implemented an alternative fix that optionally sets the missing IDs while scanning the CAS for FSes thus also avoiding scanning the CAS twice during serialization