### PR TITLE
#185 #186 #187: Handling of multipleReferencesAllowed and arrays

### DIFF
--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -617,9 +617,9 @@ class Cas:
 
             # Arrays contents are handled separately - they only have one "virtual" feature: elements
             if t.supertypeName == "uima.cas.ArrayBase":
-                if t.name == "uima.cas.FSArray":
+                if t.name == "uima.cas.FSArray" and fs.elements:
                     for ref in fs.elements:
-                        if ref.xmiID in all_fs:
+                        if not ref or ref.xmiID in all_fs:
                             continue
                         openlist.append(ref)
                 continue  # After processing any arrays, skip to the next FS in the openlist
@@ -644,9 +644,9 @@ class Cas:
                     and ts.is_array(feature.rangeTypeName)
                 ):
                     # For inlined FSArrays, we still need to scan their members
-                    if feature.rangeTypeName == "uima.cas.FSArray":
+                    if feature.rangeTypeName == "uima.cas.FSArray" and feature_value.elements:
                         for ref in feature_value.elements:
-                            if ref.xmiID in all_fs:
+                            if not ref or ref.xmiID in all_fs:
                                 continue
                             openlist.append(ref)
                     continue

--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -639,8 +639,8 @@ class Cas:
                     continue
 
                 if (
-                    include_inlinable_arrays is False
-                    and feature.multipleReferencesAllowed is not True
+                    not include_inlinable_arrays
+                    and not feature.multipleReferencesAllowed
                     and ts.is_array(feature.rangeTypeName)
                 ):
                     # For inlined FSArrays, we still need to scan their members

--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -576,7 +576,9 @@ class Cas:
 
         return all_errors
 
-    def _find_all_fs(self, generate_missing_ids: bool = True) -> Iterable[FeatureStructure]:
+    def _find_all_fs(
+        self, generate_missing_ids: bool = True, include_inlinable_arrays: bool = False
+    ) -> Iterable[FeatureStructure]:
         """This function traverses the whole CAS in order to find all directly and indirectly referenced
         feature structures. Traversing is needed as it can be that a feature structure is not added to the sofa but
         referenced by another feature structure as a feature."""
@@ -612,33 +614,52 @@ class Cas:
             all_fs[fs.xmiID] = fs
 
             t = ts.get_type(fs.type)
+
+            # Arrays contents are handled separately - they only have one "virtual" feature: elements
+            if t.supertypeName == "uima.cas.ArrayBase":
+                if t.name == "uima.cas.FSArray":
+                    for ref in fs.elements:
+                        if ref.xmiID in all_fs:
+                            continue
+                        openlist.append(ref)
+                continue
+
+            # For non-array types, we look at the features - this includes also FSList-types
             for feature in t.all_features:
                 feature_name = feature.name
 
                 if feature_name == "sofa":
                     continue
 
-                if (
-                    ts.is_primitive(feature.rangeTypeName)
-                    or ts.is_primitive_collection(feature.rangeTypeName)
-                    or ts.is_primitive_collection(fs.type)
-                ):
+                if ts.is_primitive(feature.rangeTypeName):
                     continue
-                elif ts.is_collection(fs.type, feature):
-                    lst = getattr(fs, feature_name)
-                    if lst is None:
-                        continue
 
-                    for referenced_fs in lst:
-                        if referenced_fs.xmiID not in all_fs:
-                            openlist.append(referenced_fs)
-                else:
-                    referenced_fs = getattr(fs, feature_name)
-                    if referenced_fs is None:
-                        continue
+                feature_value = getattr(fs, feature_name)
+                if feature_value is None:
+                    continue
 
-                    if referenced_fs.xmiID not in all_fs:
-                        openlist.append(referenced_fs)
+                if (
+                    include_inlinable_arrays is False
+                    and feature.multipleReferencesAllowed is not True
+                    and ts.is_array(feature.rangeTypeName)
+                ):
+                    # For inlined FSArrays, we still need to scan their members
+                    if feature.rangeTypeName == "uima.cas.FSArray":
+                        for ref in feature_value.elements:
+                            if ref.xmiID in all_fs:
+                                continue
+                            openlist.append(ref)
+                    continue
+
+                if not hasattr(feature_value, "xmiID"):
+                    raise AttributeError(
+                        f"Feature [{feature_name}] should point to a [{feature.rangeTypeName}] but the feature value is a [{type(feature_value)}] with the value [{feature_value}]"
+                    )
+
+                if feature_value.xmiID in all_fs:
+                    continue
+
+                openlist.append(feature_value)
 
         yield from all_fs.values()
 

--- a/cassis/cas.py
+++ b/cassis/cas.py
@@ -622,7 +622,7 @@ class Cas:
                         if ref.xmiID in all_fs:
                             continue
                         openlist.append(ref)
-                continue
+                continue  # After processing any arrays, skip to the next FS in the openlist
 
             # For non-array types, we look at the features - this includes also FSList-types
             for feature in t.all_features:

--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -616,7 +616,7 @@ class TypeSystem:
         # Arrays are inheritance-final, so we do not need to check the inheritance hierarchy
         return type_name in _PRIMITIVE_ARRAY_TYPES
 
-    def is_array(self, type_name) -> bool:
+    def is_array(self, type_name: str) -> bool:
         """Checks if the type identified by `type_name` is an array.
 
         Args:

--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -112,7 +112,6 @@ _PRIMITIVE_COLLECTION_TYPES = {
     "uima.cas.DoubleArray",
 }
 
-
 _PRIMITIVE_ARRAY_TYPES = {
     "uima.cas.FloatArray",
     "uima.cas.IntegerArray",
@@ -121,7 +120,12 @@ _PRIMITIVE_ARRAY_TYPES = {
     "uima.cas.ShortArray",
     "uima.cas.LongArray",
     "uima.cas.DoubleArray",
+    "uima.cas.StringArray",
 }
+
+_INHERITANCE_FINAL_TYPES = _PRIMITIVE_ARRAY_TYPES
+
+_ARRAY_TYPES = _PRIMITIVE_ARRAY_TYPES | {"uima.cas.FSArray"}
 
 
 def _string_to_valid_classname(name: str):
@@ -163,7 +167,7 @@ class FeatureStructure:
             raise NotImplementedError()
 
     def get(self, path: str) -> Optional[Any]:
-        """ Recursively gets an attribute, e.g. fs.get("a.b.c") would return attribute `c` of `b` of `a`.
+        """Recursively gets an attribute, e.g. fs.get("a.b.c") would return attribute `c` of `b` of `a`.
 
         If you have nested feature structures, e.g. a feature structure with feature `a` that has a feature `b` that
         has a feature `c`, some of which can be `None`, then you can use the following:
@@ -422,6 +426,7 @@ class TypeSystem:
 
         # Array
         t = self.create_type(name="uima.cas.ArrayBase", supertypeName="uima.cas.TOP")
+        # FIXME "elements" is not actually a feature according to the UIMA Java SDK
         self.create_feature(t, name="elements", rangeTypeName="uima.cas.TOP", multipleReferencesAllowed=True)
 
         self.create_type(name="uima.cas.FSArray", supertypeName="uima.cas.ArrayBase")
@@ -506,6 +511,9 @@ class TypeSystem:
         Returns:
             The newly created type
         """
+        if supertypeName in _INHERITANCE_FINAL_TYPES:
+            raise ValueError(f"[{name}] cannot inhert from [{supertypeName}] because the latter is inheritance final")
+
         if self.contains_type(name) and name not in _PREDEFINED_TYPES:
             msg = "Type with name [{0}] already exists!".format(name)
             raise ValueError(msg)
@@ -604,10 +612,23 @@ class TypeSystem:
         """
         if type_name == TOP_TYPE_NAME:
             return False
-        elif type_name in _PRIMITIVE_ARRAY_TYPES:
-            return True
-        else:
-            return self.is_primitive_array(self.get_type(type_name).supertypeName)
+
+        # Arrays are inheritance-final, so we do not need to check the inheritance hierarchy
+        return type_name in _PRIMITIVE_ARRAY_TYPES
+
+    def is_array(self, type_name) -> bool:
+        """Checks if the type identified by `type_name` is an array.
+
+        Args:
+            type_name: The name of the type to query for.
+        Returns:
+            Returns True if the type identified by `type_name` is an array type, else False
+        """
+        if type_name == TOP_TYPE_NAME:
+            return False
+
+        # Arrays are inheritance-final, so we do not need to check the inheritance hierarchy
+        return type_name in _ARRAY_TYPES
 
     def subsumes(self, parent_name: str, child_name: str) -> bool:
         """Determines if the type `child_name` is a child of `parent_name`.
@@ -639,7 +660,7 @@ class TypeSystem:
         elementType: str = None,
         description: str = None,
         multipleReferencesAllowed: bool = None,
-    ):
+    ) -> Feature:
         """Adds a feature to the given type.
 
         Args:
@@ -676,6 +697,8 @@ class TypeSystem:
         )
 
         type_.add_feature(feature)
+
+        return feature
 
     @deprecation.deprecated(details="Use create_feature")
     def add_feature(
@@ -732,7 +755,7 @@ class TypeSystem:
     def typecheck(self, fs: FeatureStructure) -> List[TypeCheckError]:
         """Checks whether a feature structure is type sound.
 
-        Currently only checks `uima.cas.FSArray` and `uima.cas.FSList`.
+        Currently only checks `uima.cas.FSArray`.
 
         Args:
             fs: The feature structure to type check.
@@ -744,11 +767,10 @@ class TypeSystem:
 
         t = self.get_type(fs.type)
         for f in t.all_features:
-            # Check FS collections
-            if f.rangeTypeName == "uima.cas.FSArray" or f.rangeTypeName == "uima.cas.FSList":
+            if f.rangeTypeName == "uima.cas.FSArray":
                 # We check for every element that it is of type `elementType` or a child thereof
                 element_type = f.elementType or TOP_TYPE_NAME
-                for e in fs.value(f.name):
+                for e in fs.value(f.name).elements:
                     if not self.subsumes(element_type, e.type):
                         msg = "Member of [{0}] has unsound type: was [{1}], need [{2}]!".format(
                             f.rangeTypeName, e.type, element_type

--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -608,7 +608,7 @@ class TypeSystem:
         Args:
             type_name: The name of the type to query for.
         Returns:
-            Returns True if the type identified by `type_name` is a primitive array type, else False
+            Returns `True` if the type identified by `type_name` is a primitive array type, else `False`
         """
         if type_name == TOP_TYPE_NAME:
             return False
@@ -622,7 +622,7 @@ class TypeSystem:
         Args:
             type_name: The name of the type to query for.
         Returns:
-            Returns True if the type identified by `type_name` is an array type, else False
+            Returns `True` if the type identified by `type_name` is an array type, else `False`
         """
         if type_name == TOP_TYPE_NAME:
             return False

--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -768,9 +768,12 @@ class TypeSystem:
         t = self.get_type(fs.type)
         for f in t.all_features:
             if f.rangeTypeName == "uima.cas.FSArray":
+                feature_value = fs.value(f.name)
+                if not feature_value.elements:
+                    continue
                 # We check for every element that it is of type `elementType` or a child thereof
                 element_type = f.elementType or TOP_TYPE_NAME
-                for e in fs.value(f.name).elements:
+                for e in feature_value.elements:
                     if not self.subsumes(element_type, e.type):
                         msg = "Member of [{0}] has unsound type: was [{1}], need [{2}]!".format(
                             f.rangeTypeName, e.type, element_type

--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -185,9 +185,7 @@ class CasXmiDeserializer:
                     # process it
                     if isinstance(value, str):
                         FSType = typesystem.get_type(feature.rangeTypeName)
-                        elements = FSType(
-                            elements=self._parse_primitive_array(feature.rangeTypeName, value)
-                        )
+                        elements = FSType(elements=self._parse_primitive_array(feature.rangeTypeName, value))
                         setattr(fs, feature_name, elements)
                 else:
                     # Resolve references here
@@ -474,14 +472,14 @@ class CasXmiSerializer:
 
             if (
                 ts.is_instance_of(feature.rangeTypeName, "uima.cas.StringArray")
-                and feature.multipleReferencesAllowed is not True
+                and not feature.multipleReferencesAllowed
             ):
                 for e in value.elements:
                     child = etree.SubElement(elem, feature_name)
                     child.text = e
-            elif ts.is_primitive_array(feature.rangeTypeName) and feature.multipleReferencesAllowed is not True:
+            elif ts.is_primitive_array(feature.rangeTypeName) and not feature.multipleReferencesAllowed:
                 elem.attrib[feature_name] = self._serialize_primitive_array(feature.rangeTypeName, value.elements)
-            elif feature.rangeTypeName == "uima.cas.FSArray" and feature.multipleReferencesAllowed is not True:
+            elif feature.rangeTypeName == "uima.cas.FSArray" and not feature.multipleReferencesAllowed:
                 elem.attrib[feature_name] = " ".join(str(e.xmiID) for e in value.elements)
             elif feature_name == "sofa":
                 elem.attrib[feature_name] = str(value.xmiID)

--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -184,7 +184,10 @@ class CasXmiDeserializer:
                     # them again, so we check if the value is still a string (i.e. attribute value) and only then
                     # process it
                     if isinstance(value, str):
-                        elements = self._parse_primitive_array(typesystem.get_type(feature.rangeTypeName), value)
+                        FSType = typesystem.get_type(feature.rangeTypeName)
+                        elements = FSType(
+                            elements=self._parse_primitive_array(typesystem.get_type(feature.rangeTypeName), value)
+                        )
                         setattr(fs, feature_name, elements)
                 else:
                     # Resolve references here
@@ -323,11 +326,11 @@ class CasXmiDeserializer:
             or type.name == "uima.cas.ShortArray"
             or type.name == "uima.cas.LongArray"
         ):
-            return type(elements=[int(e) for e in elements])
+            return [int(e) for e in elements]
         elif type.name == "uima.cas.BooleanArray":
-            return type(elements=[self._parse_bool(e) for e in elements])
+            return [self._parse_bool(e) for e in elements]
         elif type.name == "uima.cas.ByteArray":
-            return type(elements=list(bytearray.fromhex(value)))
+            return list(bytearray.fromhex(value))
         else:
             raise ValueError(f"Not a primitive collection: {type.name}")
 

--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -176,7 +176,7 @@ class CasXmiDeserializer:
                     continue
                 elif typesystem.is_primitive_array(fs.type) and feature_name == "elements":
                     # Separately rendered arrays (typically used with multipleReferencesAllowed = True)
-                    elements = self._parse_primitive_array(typesystem.get_type(fs.type), value)
+                    elements = self._parse_primitive_array(fs.type, value)
                     setattr(fs, feature_name, elements)
                 elif typesystem.is_primitive_array(feature.rangeTypeName):
                     # Array feature rendered inline (multipleReferencesAllowed = False|None)
@@ -186,7 +186,7 @@ class CasXmiDeserializer:
                     if isinstance(value, str):
                         FSType = typesystem.get_type(feature.rangeTypeName)
                         elements = FSType(
-                            elements=self._parse_primitive_array(typesystem.get_type(feature.rangeTypeName), value)
+                            elements=self._parse_primitive_array(feature.rangeTypeName, value)
                         )
                         setattr(fs, feature_name, elements)
                 else:
@@ -314,25 +314,25 @@ class CasXmiDeserializer:
         self._max_xmi_id = max(attributes["xmiID"], self._max_xmi_id)
         return AnnotationType(**attributes)
 
-    def _parse_primitive_array(self, type: Type, value: str) -> List:
+    def _parse_primitive_array(self, type_name: str, value: str) -> List:
         """ Primitive collections are serialized as white space seperated primitive values"""
 
         # TODO: Use type name global variable here instead of hardcoded string literal
         elements = value.split(" ")
-        if type.name == "uima.cas.FloatArray" or type.name == "uima.cas.DoubleArray":
+        if type_name == "uima.cas.FloatArray" or type_name == "uima.cas.DoubleArray":
             return [float(e) for e in elements]
         elif (
-            type.name == "uima.cas.IntegerArray"
-            or type.name == "uima.cas.ShortArray"
-            or type.name == "uima.cas.LongArray"
+            type_name == "uima.cas.IntegerArray"
+            or type_name == "uima.cas.ShortArray"
+            or type_name == "uima.cas.LongArray"
         ):
             return [int(e) for e in elements]
-        elif type.name == "uima.cas.BooleanArray":
+        elif type_name == "uima.cas.BooleanArray":
             return [self._parse_bool(e) for e in elements]
-        elif type.name == "uima.cas.ByteArray":
+        elif type_name == "uima.cas.ByteArray":
             return list(bytearray.fromhex(value))
         else:
-            raise ValueError(f"Not a primitive collection: {type.name}")
+            raise ValueError(f"Not a primitive collection: {type_name}")
 
     def _parse_bool(self, s: str) -> bool:
         if s == "true":

--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -424,7 +424,7 @@ class CasXmiSerializer:
         elem.attrib["{http://www.omg.org/XMI}id"] = str(fs.xmiID)
 
         # Case where arrays are rendered as separate elements (not inline) for use with multipleReferencesAllowed = True
-        if ts.is_primitive_array(fs.type) or fs.type == "uima.cas.FSArray":
+        if ts.is_primitive_array(fs.type) or fs.type == "uima.cas.FSArray" and fs.elements:
             if ts.is_instance_of(fs.type, "uima.cas.StringArray"):
                 # String arrays need to be serialized to a series of child elements, as strings can
                 # contain whitespaces. Consider e.g. the array ['likes cats, 'likes dogs']. If we would
@@ -473,13 +473,14 @@ class CasXmiSerializer:
             if (
                 ts.is_instance_of(feature.rangeTypeName, "uima.cas.StringArray")
                 and not feature.multipleReferencesAllowed
+                and value.elements
             ):
                 for e in value.elements:
                     child = etree.SubElement(elem, feature_name)
                     child.text = e
-            elif ts.is_primitive_array(feature.rangeTypeName) and not feature.multipleReferencesAllowed:
+            elif ts.is_primitive_array(feature.rangeTypeName) and not feature.multipleReferencesAllowed and value.elements:
                 elem.attrib[feature_name] = self._serialize_primitive_array(feature.rangeTypeName, value.elements)
-            elif feature.rangeTypeName == "uima.cas.FSArray" and not feature.multipleReferencesAllowed:
+            elif feature.rangeTypeName == "uima.cas.FSArray" and not feature.multipleReferencesAllowed and value.elements:
                 elem.attrib[feature_name] = " ".join(str(e.xmiID) for e in value.elements)
             elif feature_name == "sofa":
                 elem.attrib[feature_name] = str(value.xmiID)

--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -7,7 +7,7 @@ import attr
 from lxml import etree
 
 from cassis.cas import Cas, IdGenerator, Sofa, View
-from cassis.typesystem import _PRIMITIVE_ARRAY_TYPES, FeatureStructure, TypeNotFoundError, TypeSystem
+from cassis.typesystem import _PRIMITIVE_ARRAY_TYPES, FeatureStructure, Type, TypeNotFoundError, TypeSystem
 
 
 @attr.s
@@ -152,6 +152,7 @@ class CasXmiDeserializer:
                 self._clear_elem(elem)
 
         # Post-process feature values
+        StringArray = typesystem.get_type("uima.cas.StringArray")
         referenced_fs = set()
         for xmi_id, fs in feature_structures.items():
             t = typesystem.get_type(fs.type)
@@ -170,25 +171,29 @@ class CasXmiDeserializer:
                     # We already parsed string arrays to a Python list of string
                     # before, so we do not need to work more on this
                     continue
-                elif typesystem.is_primitive(feature.rangeTypeName) or typesystem.is_primitive_collection(
-                    feature.rangeTypeName
-                ):
+                elif typesystem.is_primitive(feature.rangeTypeName):
                     # TODO: Parse feature values to their real type here, e.g. parse ints or floats
                     continue
                 elif typesystem.is_primitive_array(fs.type) and feature_name == "elements":
-                    elements = self._parse_primitive_array(fs.type, value)
+                    # Separately rendered arrays (typically used with multipleReferencesAllowed = True)
+                    elements = self._parse_primitive_array(typesystem.get_type(fs.type), value)
                     setattr(fs, feature_name, elements)
                 elif typesystem.is_primitive_array(feature.rangeTypeName):
-                    elements = self._parse_primitive_array(feature.rangeTypeName, value)
-                    setattr(fs, feature_name, elements)
+                    # Array feature rendered inline (multipleReferencesAllowed = False|None)
+                    # We also end up here for array features that were rendered as child elements. No need to parse
+                    # them again, so we check if the value is still a string (i.e. attribute value) and only then
+                    # process it
+                    if isinstance(value, str):
+                        elements = self._parse_primitive_array(typesystem.get_type(feature.rangeTypeName), value)
+                        setattr(fs, feature_name, elements)
                 else:
                     # Resolve references here
                     if value is None:
                         continue
 
                     # Resolve references
-                    if typesystem.is_collection(fs.type, feature):
-                        # A collection of references is a list of integers separated
+                    if fs.type == "uima.cas.FSArray" or feature.rangeTypeName == "uima.cas.FSArray":
+                        # An array of references is a list of integers separated
                         # by single spaces, e.g. <foo:bar elements="1 2 3 42" />
                         targets = []
                         for ref in value.split():
@@ -196,6 +201,10 @@ class CasXmiDeserializer:
                             target = feature_structures[target_id]
                             targets.append(target)
                             referenced_fs.add(target_id)
+                        if feature.rangeTypeName == "uima.cas.FSArray":
+                            # Wrap inline array into the appropriate array object
+                            ArrayType = typesystem.get_type("uima.cas.FSArray")
+                            targets = ArrayType(elements=targets)
                         setattr(fs, feature_name, targets)
                     else:
                         target_id = int(value)
@@ -290,28 +299,37 @@ class CasXmiDeserializer:
         if "type" in attributes:
             attributes["type_"] = attributes.pop("type")
 
+        # Arrays which were represented as nested elements in the XMI have so far have only been parsed into a Python
+        # arrays. Now we convert them to proper UIMA arrays
+        if not typesystem.is_primitive_array(type_name):
+            for feature_name, feature_value in children.items():
+                feature = AnnotationType.get_feature(feature_name)
+                if typesystem.is_primitive_array(feature.rangeTypeName):
+                    ArrayType = typesystem.get_type(feature.rangeTypeName)
+                    attributes[feature_name] = ArrayType(elements=attributes[feature_name])
+
         self._max_xmi_id = max(attributes["xmiID"], self._max_xmi_id)
         return AnnotationType(**attributes)
 
-    def _parse_primitive_array(self, type_name: str, value: str) -> List:
+    def _parse_primitive_array(self, type: Type, value: str) -> List:
         """ Primitive collections are serialized as white space seperated primitive values"""
 
         # TODO: Use type name global variable here instead of hardcoded string literal
         elements = value.split(" ")
-        if type_name == "uima.cas.FloatArray" or type_name == "uima.cas.DoubleArray":
+        if type.name == "uima.cas.FloatArray" or type.name == "uima.cas.DoubleArray":
             return [float(e) for e in elements]
         elif (
-            type_name == "uima.cas.IntegerArray"
-            or type_name == "uima.cas.ShortArray"
-            or type_name == "uima.cas.LongArray"
+            type.name == "uima.cas.IntegerArray"
+            or type.name == "uima.cas.ShortArray"
+            or type.name == "uima.cas.LongArray"
         ):
-            return [int(e) for e in elements]
-        elif type_name == "uima.cas.BooleanArray":
-            return [self._parse_bool(e) for e in elements]
-        elif type_name == "uima.cas.ByteArray":
-            return list(bytearray.fromhex(value))
+            return type(elements=[int(e) for e in elements])
+        elif type.name == "uima.cas.BooleanArray":
+            return type(elements=[self._parse_bool(e) for e in elements])
+        elif type.name == "uima.cas.ByteArray":
+            return type(elements=list(bytearray.fromhex(value)))
         else:
-            raise ValueError(f"Not a primitive collection: {type_name}")
+            raise ValueError(f"Not a primitive collection: {type.name}")
 
     def _parse_bool(self, s: str) -> bool:
         if s == "true":
@@ -404,6 +422,31 @@ class CasXmiSerializer:
         # Serialize common attributes
         elem.attrib["{http://www.omg.org/XMI}id"] = str(fs.xmiID)
 
+        # Case where arrays are rendered as separate elements (not inline) for use with multipleReferencesAllowed = True
+        if ts.is_primitive_array(fs.type) or fs.type == "uima.cas.FSArray":
+            if ts.is_instance_of(fs.type, "uima.cas.StringArray"):
+                # String arrays need to be serialized to a series of child elements, as strings can
+                # contain whitespaces. Consider e.g. the array ['likes cats, 'likes dogs']. If we would
+                # serialize it as an attribute, it would look like
+                #
+                # <my:fs elements="likes cats likes dogs" />
+                #
+                # which looses the information about the whitespace. Instead, we serialize it to
+                #
+                # <my:fs>
+                #   <elements>likes cats</elements>
+                #   <elements>likes dogs</elements>
+                # </my:fs>
+                for e in fs.elements:
+                    child = etree.SubElement(elem, "elements")
+                    child.text = e
+            elif fs.type == "uima.cas.FSArray":
+                elements = " ".join(str(e.xmiID) for e in fs.elements)
+                elem.attrib["elements"] = elements
+            else:
+                elem.attrib["elements"] = self._serialize_primitive_array(fs.type, fs.elements)
+            return
+
         # Serialize feature attributes
         t = ts.get_type(fs.type)
         for feature in t.all_features:
@@ -426,35 +469,21 @@ class CasXmiSerializer:
                 sofa: Sofa = getattr(fs, "sofa")
                 value = sofa._offset_converter.cassis_to_uima(value)
 
-            if (ts.is_instance_of(fs.type, "uima.cas.StringArray") and feature_name == "elements") or ts.is_instance_of(
-                feature.rangeTypeName, "uima.cas.StringArray"
+            if (
+                ts.is_instance_of(feature.rangeTypeName, "uima.cas.StringArray")
+                and feature.multipleReferencesAllowed is not True
             ):
-                # String arrays need to be serialized to a series of child elements, as strings can
-                # contain whitespaces. Consider e.g. the array ['likes cats, 'likes dogs']. If we would
-                # serialize it as an attribute, it would look like
-                #
-                # <my:fs elements="likes cats likes dogs" />
-                #
-                # which looses the information about the whitespace. Instead, we serialize it to
-                #
-                # <my:fs>
-                #   <elements>likes cats</elements>
-                #   <elements>likes dogs</elements>
-                # </my:fs>
-                for e in value:
+                for e in value.elements:
                     child = etree.SubElement(elem, feature_name)
                     child.text = e
-            elif ts.is_primitive_array(fs.type) and feature_name == "elements":
-                elem.attrib[feature_name] = self._serialize_primitive_array(fs.type, value)
-            elif ts.is_primitive_array(feature.rangeTypeName):
-                elem.attrib[feature_name] = self._serialize_primitive_array(feature.rangeTypeName, value)
+            elif ts.is_primitive_array(feature.rangeTypeName) and feature.multipleReferencesAllowed is not True:
+                elem.attrib[feature_name] = self._serialize_primitive_array(feature.rangeTypeName, value.elements)
+            elif feature.rangeTypeName == "uima.cas.FSArray" and feature.multipleReferencesAllowed is not True:
+                elem.attrib[feature_name] = " ".join(str(e.xmiID) for e in value.elements)
             elif feature_name == "sofa":
                 elem.attrib[feature_name] = str(value.xmiID)
             elif ts.is_primitive(feature.rangeTypeName):
                 elem.attrib[feature_name] = str(value)
-            elif ts.is_collection(fs.type, feature):
-                elements = " ".join(str(e.xmiID) for e in value)
-                elem.attrib[feature_name] = elements
             else:
                 # We need to encode non-primitive features as a reference
                 elem.attrib[feature_name] = str(value.xmiID)

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -254,7 +254,7 @@ def test_select_returns_feature_structures(cas_with_collections_xmi, typesystem_
 
     arrs = list(cas.select("uima.cas.StringArray"))
 
-    assert len(arrs) == 2
+    assert len(arrs) == 3
 
 
 # Covered text

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -252,7 +252,7 @@ def test_select_returns_feature_structures(cas_with_collections_xmi, typesystem_
     typesystem = load_typesystem(typesystem_with_collections_xml)
     cas = load_cas_from_xmi(cas_with_collections_xmi, typesystem=typesystem)
 
-    arrs = list(cas.select("uima.cas.StringArray"))
+    arrs = cas.select("uima.cas.StringArray")
 
     assert len(arrs) == 3
 

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -252,9 +252,9 @@ def test_select_returns_feature_structures(cas_with_collections_xmi, typesystem_
     typesystem = load_typesystem(typesystem_with_collections_xml)
     cas = load_cas_from_xmi(cas_with_collections_xmi, typesystem=typesystem)
 
-    arrs = list(cas.select("cassis.StringArray"))
+    arrs = list(cas.select("uima.cas.StringArray"))
 
-    assert len(arrs) == 1
+    assert len(arrs) == 2
 
 
 # Covered text
@@ -454,3 +454,29 @@ def test_fail_on_duplicate_fs_id(small_typesystem_xml):
 
     with pytest.raises(ValueError):
         list(cas._find_all_fs())
+
+
+def test_scanning_for_transitively_referenced_integer_array():
+    typesystem = TypeSystem()
+    Foo = typesystem.create_type("Foo")
+    typesystem.create_feature(
+        Foo,
+        "ref",
+        rangeTypeName="uima.cas.IntegerArray",
+        elementType="uima.cas.Integer",
+        multipleReferencesAllowed=True,
+    )
+
+    cas = Cas(typesystem)
+
+    foo = Foo()
+    cas.add(foo)
+
+    IntegerArray = typesystem.get_type("uima.cas.IntegerArray")
+    int_array = IntegerArray()
+    int_array.elements = [1, 2, 3]
+    foo.ref = int_array
+
+    all_fs = list(cas._find_all_fs())
+
+    assert int_array in all_fs

--- a/tests/test_files/typesystems/typesystem_with_collections.xml
+++ b/tests/test_files/typesystems/typesystem_with_collections.xml
@@ -2,11 +2,6 @@
 <typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
     <types>
         <typeDescription>
-            <name>cassis.StringArray</name>
-            <description/>
-            <supertypeName>uima.cas.StringArray</supertypeName>
-        </typeDescription>
-        <typeDescription>
             <name>cassis.Group</name>
             <description/>
             <supertypeName>uima.tcas.Annotation</supertypeName>
@@ -19,7 +14,7 @@
                 <featureDescription>
                     <name>collection2</name>
                     <description/>
-                    <rangeTypeName>cassis.StringArray</rangeTypeName>
+                    <rangeTypeName>uima.cas.IntegerArray</rangeTypeName>
                 </featureDescription>
             </features>
         </typeDescription>

--- a/tests/test_files/xmi/cas_with_collections.xmi
+++ b/tests/test_files/xmi/cas_with_collections.xmi
@@ -14,20 +14,16 @@
 		<elements>SNOMEDCT_US</elements>
 	</cas:StringArray>
 
-	<cassis:StringArray xmi:id="4">
+	<cas:StringArray xmi:id="4">
 		<elements>A</elements>
 		<elements>B</elements>
 		<elements>C</elements>
-	</cassis:StringArray>
+	</cas:StringArray>
 
-	<cassis:Group xmi:id="5" sofa="1">
+	<cassis:Group xmi:id="5" sofa="1" collection2="1 2 3">
 		<collection1>A</collection1>
 		<collection1>B</collection1>
 		<collection1>C</collection1>
-
-		<collection2>x</collection2>
-		<collection2>y</collection2>
-		<collection2>z</collection2>
 	</cassis:Group>
 
 	<cas:FSArray xmi:id="6" elements="2 3 4 5" />
@@ -37,22 +33,7 @@
 	<cas:NonEmptyFSList xmi:id="9" head="5" tail="10" />
 	<cas:EmptyFSList xmi:id="10"/>
 
-    <cas:FloatArray xmi:id="11" elements="0.7275637 0.054665208 0.6832234 0.0479393"/>
-    <cas:IntegerArray xmi:id="12" elements="1325939940 -248792245 1190043011 -1255373459 -1436456258 392236186"/>
-    <cas:StringArray xmi:id="13">
-        <elements>aaiguewilz</elements>
-        <elements>orarzvmgty</elements>
-        <elements>mkshhvglpk</elements>
-        <elements>ffvdpcdvbx</elements>
-        <elements>jsqcoqzpxb</elements>
-    </cas:StringArray>
-    <cas:BooleanArray xmi:id="14" elements="false true false"/>
-    <cas:ByteArray xmi:id="15" elements="42DB3064"/>
-    <cas:ShortArray xmi:id="16" elements="1929 13467 15132 15893"/>
-    <cas:LongArray xmi:id="17" elements="2516571677013944794"/>
-    <cas:DoubleArray xmi:id="18" elements="0.4362829094329638 0.6487936445670887 0.6959691863162578"/>
-
 	<cas:Sofa xmi:id="1" sofaNum="1" sofaID="_InitialView" mimeType="text/plain"
               sofaString="Joe waited for the train . The train was late ."/>
-	<cas:View members="2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18" sofa="1"/>
+	<cas:View members="2 3 4 5 6 7 8 9 10" sofa="1"/>
 </xmi:XMI>

--- a/tests/test_files/xmi/cas_with_collections.xmi
+++ b/tests/test_files/xmi/cas_with_collections.xmi
@@ -33,7 +33,22 @@
 	<cas:NonEmptyFSList xmi:id="9" head="5" tail="10" />
 	<cas:EmptyFSList xmi:id="10"/>
 
+    <cas:FloatArray xmi:id="11" elements="0.7275637 0.054665208 0.6832234 0.0479393"/>
+    <cas:IntegerArray xmi:id="12" elements="1325939940 -248792245 1190043011 -1255373459 -1436456258 392236186"/>
+    <cas:StringArray xmi:id="13">
+        <elements>aaiguewilz</elements>
+        <elements>orarzvmgty</elements>
+        <elements>mkshhvglpk</elements>
+        <elements>ffvdpcdvbx</elements>
+        <elements>jsqcoqzpxb</elements>
+    </cas:StringArray>
+    <cas:BooleanArray xmi:id="14" elements="false true false"/>
+    <cas:ByteArray xmi:id="15" elements="42DB3064"/>
+    <cas:ShortArray xmi:id="16" elements="1929 13467 15132 15893"/>
+    <cas:LongArray xmi:id="17" elements="2516571677013944794"/>
+    <cas:DoubleArray xmi:id="18" elements="0.4362829094329638 0.6487936445670887 0.6959691863162578"/>
+
 	<cas:Sofa xmi:id="1" sofaNum="1" sofaID="_InitialView" mimeType="text/plain"
               sofaString="Joe waited for the train . The train was late ."/>
-	<cas:View members="2 3 4 5 6 7 8 9 10" sofa="1"/>
+	<cas:View members="2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18" sofa="1"/>
 </xmi:XMI>

--- a/tests/test_typesystem.py
+++ b/tests/test_typesystem.py
@@ -692,3 +692,10 @@ def test_set_path_not_found(cas_with_references_xmi, webanno_typesystem_xml):
 
     with pytest.raises(AttributeError):
         first_arg.set("target.bar", 42)
+
+
+def test_cannot_extend_final_type():
+    typesystem = TypeSystem()
+
+    with pytest.raises(ValueError):
+        typesystem.create_type("ArraySubType", "uima.cas.IntegerArray")

--- a/tests/test_typesystem.py
+++ b/tests/test_typesystem.py
@@ -305,7 +305,7 @@ def test_is_primitive_collection(type_name: str, expected: bool):
         ("uima.cas.FSArray", False),
         ("uima.cas.FloatArray", True),
         ("uima.cas.IntegerArray", True),
-        ("uima.cas.StringArray", False),
+        ("uima.cas.StringArray", True),
         ("uima.cas.ListBase", False),
         ("uima.cas.FSList", False),
         ("uima.cas.EmptyFSList", False),
@@ -595,13 +595,14 @@ def test_typchecking_fs_array():
     MyValue = cas.typesystem.create_type(name="test.MyValue", supertypeName="uima.cas.TOP")
     MyOtherValue = cas.typesystem.create_type(name="test.MyOtherValue", supertypeName="uima.cas.TOP")
     MyCollection = cas.typesystem.create_type("test.MyCollection", supertypeName="uima.cas.TOP")
+    FSArray = cas.typesystem.get_type("uima.cas.FSArray")
 
     cas.typesystem.create_feature(type_=MyValue, name="value", rangeTypeName="uima.cas.String")
     cas.typesystem.create_feature(
         type_=MyCollection, name="members", rangeTypeName="uima.cas.FSArray", elementType="test.MyValue"
     )
 
-    members = [MyValue(value="foo"), MyValue(value="bar"), MyOtherValue()]
+    members = FSArray(elements=[MyValue(value="foo"), MyValue(value="bar"), MyOtherValue()])
 
     collection = MyCollection(members=members)
 
@@ -626,7 +627,7 @@ def test_get_set_path_semargs(cas_with_references_xmi, webanno_typesystem_xml):
     result = cas.select("de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemPred")
     assert len(result) == 1
     pred = result[0]
-    first_arg = pred.arguments[0]
+    first_arg = pred.arguments.elements[0]
 
     assert first_arg.get("target.end") == 5
     first_arg.set("target.end", 42)
@@ -687,7 +688,7 @@ def test_set_path_not_found(cas_with_references_xmi, webanno_typesystem_xml):
     result = cas.select("de.tudarmstadt.ukp.dkpro.core.api.semantics.type.SemPred")
     assert len(result) == 1
     pred = result[0]
-    first_arg = pred.arguments[0]
+    first_arg = pred.arguments.elements[0]
 
     with pytest.raises(AttributeError):
         first_arg.set("target.bar", 42)

--- a/tests/test_typesystem.py
+++ b/tests/test_typesystem.py
@@ -332,6 +332,13 @@ def test_is_primitive_collection(type_name: str, expected: bool):
     assert typesystem.is_primitive_array(type_name) == expected
 
 
+def test_is_aray():
+    cas = Cas()
+
+    for type in cas.typesystem.get_types():
+        assert cas.typesystem.is_array(type.name) == type.name.endswith("Array")
+
+
 @pytest.mark.parametrize(
     "parent_name, child_name, expected",
     [
@@ -695,7 +702,9 @@ def test_set_path_not_found(cas_with_references_xmi, webanno_typesystem_xml):
 
 
 def test_cannot_extend_final_type():
-    typesystem = TypeSystem()
+    cas = Cas()
 
-    with pytest.raises(ValueError):
-        typesystem.create_type("ArraySubType", "uima.cas.IntegerArray")
+    for type in cas.typesystem.get_types():
+        if type.name.endswith("Array"):
+            with pytest.raises(ValueError):
+                cas.typesystem.create_type("ArraySubType", "uima.cas.IntegerArray")


### PR DESCRIPTION

#185 - Transitively referenced primitive arrays not returned by _find_all_fs
#186 - Creating subtypes of inheritance-final types (arrays) is not prevented
#187 - The multipleReferencesAllowed flag on array features is not handled

- Consistently wrap arrays into their proper UIMA array types when deserializing
- Tests and code updated because in order to access the array elements it is now necessary to access them via the `elements` property of the array wrapper
- Add handling of the multipleReferencesAllowed flag in during (de)serialization