### PR TITLE
#209 - Parsing an array that was serialized using multipleReferencesAllowed=true fails

### DIFF
--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -203,7 +203,7 @@ class CasXmiDeserializer:
                 elif typesystem.is_primitive_array(fs.type) and feature_name == "elements":
                     # Separately rendered arrays (typically used with multipleReferencesAllowed = True)
                     fs[feature_name] = self._parse_primitive_array(fs.type, value)
-                elif typesystem.is_primitive_array(feature.rangeType):
+                elif typesystem.is_primitive_array(feature.rangeType) and not feature.multipleReferencesAllowed:
                     # Array feature rendered inline (multipleReferencesAllowed = False|None)
                     # We also end up here for array features that were rendered as child elements. No need to parse
                     # them again, so we check if the value is still a string (i.e. attribute value) and only then
@@ -337,7 +337,7 @@ class CasXmiDeserializer:
         return AnnotationType(**attributes)
 
     def _parse_primitive_array(self, type_: Type, value: str) -> List:
-        """Primitive collections are serialized as white space seperated primitive values"""
+        """Primitive collections are serialized as white space separated primitive values"""
 
         # TODO: Use type name global variable here instead of hardcoded string literal
         elements = value.split(" ")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -104,6 +104,20 @@ def cas_with_empty_array_references_xmi(cas_with_empty_array_references_path):
         return f.read()
 
 
+# CAS with multipleReferencesAllowed=true on string array
+
+
+@pytest.fixture
+def cas_with_multiple_references_allowed_string_array_path():
+    return os.path.join(FIXTURE_DIR, "xmi", "cas_with_multiple_references_allowed_string_array.xmi")
+
+
+@pytest.fixture
+def cas_with_multiple_references_allowed_string_array_xmi(cas_with_multiple_references_allowed_string_array_path):
+    with open(cas_with_multiple_references_allowed_string_array_path, "r") as f:
+        return f.read()
+
+
 # CAS with reserved names
 
 
@@ -270,6 +284,20 @@ def typesystem_with_collections_path():
 @pytest.fixture
 def typesystem_with_collections_xml(typesystem_with_collections_path):
     with open(typesystem_with_collections_path, "r") as f:
+        return f.read()
+
+
+# CAS with multipleReferencesAllowed=true on string array
+
+
+@pytest.fixture
+def typesystem_with_multiple_references_allowed_path():
+    return os.path.join(FIXTURE_DIR, "typesystems", "typesystem_with_multiple_references_allowed.xml")
+
+
+@pytest.fixture
+def typesystem_with_multiple_references_allowed_xml(typesystem_with_multiple_references_allowed_path):
+    with open(typesystem_with_multiple_references_allowed_path, "r") as f:
         return f.read()
 
 

--- a/tests/test_files/typesystems/typesystem_with_multiple_references_allowed.xml
+++ b/tests/test_files/typesystems/typesystem_with_multiple_references_allowed.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
+    <types>
+        <typeDescription>
+            <name>test.type</name>
+            <description/>
+            <supertypeName>uima.tcas.Annotation</supertypeName>
+            <features>
+                <featureDescription>
+                    <name>target</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.StringArray</rangeTypeName>
+                    <elementType>uima.cas.String</elementType>
+                    <multipleReferencesAllowed>true</multipleReferencesAllowed>
+                </featureDescription>
+            </features>
+        </typeDescription>
+    </types>
+</typeSystemDescription>

--- a/tests/test_files/xmi/cas_with_multiple_references_allowed_string_array.xmi
+++ b/tests/test_files/xmi/cas_with_multiple_references_allowed_string_array.xmi
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<xmi:XMI xmi:version="2.0" xmlns:cas="http:///uima/cas.ecore"
+		 xmlns:tcas="http:///uima/tcas.ecore"
+		 xmlns:xmi="http://www.omg.org/XMI"
+		 xmlns:test="http:///test.ecore">
+
+	<cas:NULL xmi:id="0"/>
+
+    <tcas:DocumentAnnotation xmi:id="1" sofa="1" begin="0" end="47" language="x-unspecified"/>
+
+    <test:type xmi:id="2" sofa="1" target="3"/>
+
+	<cas:StringArray xmi:id="3">
+		<elements>LNC</elements>
+		<elements>MTH</elements>
+		<elements>SNOMEDCT_US</elements>
+	</cas:StringArray>
+
+	<cas:Sofa xmi:id="1" sofaNum="1" sofaID="_InitialView" mimeType="text/plain"
+              sofaString="Joe waited for the train . The train was late ."/>
+	<cas:View members="1 2" sofa="1"/>
+</xmi:XMI>

--- a/tests/test_xmi.py
+++ b/tests/test_xmi.py
@@ -28,6 +28,10 @@ FIXTURES = [
         pytest.lazy_fixture("cas_has_fs_with_no_namespace_xmi"),
         pytest.lazy_fixture("typesystem_has_types_with_no_namespace_xml"),
     ),
+    (
+        pytest.lazy_fixture("cas_with_multiple_references_allowed_string_array_xmi"),
+        pytest.lazy_fixture("typesystem_with_multiple_references_allowed_xml"),
+    ),
 ]
 
 
@@ -294,14 +298,14 @@ def test_offsets_work_for_empty_sofastring():
 # Leniency
 
 
-def test_leniency_type_not_in_typeystem_lenient(cas_with_leniency_xmi, small_typesystem_xml):
+def test_leniency_type_not_in_typesystem_lenient(cas_with_leniency_xmi, small_typesystem_xml):
     typesystem = load_typesystem(small_typesystem_xml)
 
     with pytest.warns(UserWarning):
         cas = load_cas_from_xmi(cas_with_leniency_xmi, typesystem=typesystem, lenient=True)
 
 
-def test_leniency_type_not_in_typeystem_not_lenient(cas_with_leniency_xmi, small_typesystem_xml):
+def test_leniency_type_not_in_typesystem_not_lenient(cas_with_leniency_xmi, small_typesystem_xml):
     typesystem = load_typesystem(small_typesystem_xml)
 
     with pytest.raises(TypeNotFoundError):


### PR DESCRIPTION
- Fixed problem by checking the multipleReferencesAllowed feature during deserialization
- Added test