### PR TITLE
#283 - Allow reading JSON CASes with out-of-order SofaFSes

### DIFF
--- a/cassis/json.py
+++ b/cassis/json.py
@@ -102,34 +102,48 @@ class CasJsonDeserializer:
         feature_structures = {}
         json_feature_structures = data.get(FEATURE_STRUCTURES_FIELD)
         if isinstance(json_feature_structures, list):
+            def parse_and_add(json_fs_):
+                parsed = self._parse_feature_structure(typesystem, json_fs_.get(ID_FIELD), json_fs_, feature_structures)
+                feature_structures[parsed.xmiID] = parsed
+
             # According to the JSON CAS 0.4.0 spec, we should be able to do this in a single loop as SofaFSes
             # should normally appear before any FSes referring to them. However, the Java implementation currently
             # does not do this, so we do two passes to be able to read its data.
             for json_fs in json_feature_structures:
                 if json_fs.get(TYPE_FIELD) == TYPE_NAME_SOFA:
+                    # In case the Sofa references a byte array that has not been parsed yet, we need to fetch it
+                    sofa_byte_array_ref = json_fs.get(REF_FEATURE_PREFIX + FEATURE_BASE_NAME_SOFAARRAY)
+                    if sofa_byte_array_ref and not feature_structures.get(sofa_byte_array_ref):
+                        for json_fs_2 in json_feature_structures:
+                            if json_fs_2.get(ID_FIELD) == sofa_byte_array_ref:
+                                parse_and_add(json_fs_2)
                     fs_id = json_fs.get(ID_FIELD)
                     fs = self._parse_sofa(cas, fs_id, json_fs, feature_structures)
                     feature_structures[fs.xmiID] = fs
             for json_fs in json_feature_structures:
                 if json_fs.get(TYPE_FIELD) != TYPE_NAME_SOFA:
-                    fs_id = json_fs.get(ID_FIELD)
-                    fs = self._parse_feature_structure(typesystem, fs_id, json_fs, feature_structures)
-                    feature_structures[fs.xmiID] = fs
+                    parse_and_add(json_fs)
 
         if isinstance(json_feature_structures, dict):
+            def parse_and_add(fs_id_, json_fs_):
+                parsed = self._parse_feature_structure(typesystem, int(fs_id_), json_fs_, feature_structures)
+                feature_structures[parsed.xmiID] = parsed
+
             # According to the JSON CAS 0.4.0 spec, we should be able to do this in a single loop as SofaFSes
             # should normally appear before any FSes referring to them. However, the Java implementation currently
             # does not do this, so we do two passes to be able to read its data.
             for fs_id, json_fs in json_feature_structures.items():
                 if json_fs.get(TYPE_FIELD) == TYPE_NAME_SOFA:
+                    # In case the Sofa references a byte array that has not been parsed yet, we need to fetch it
+                    sofa_byte_array_ref = json_fs.get(REF_FEATURE_PREFIX + FEATURE_BASE_NAME_SOFAARRAY)
+                    if sofa_byte_array_ref and not feature_structures.get(sofa_byte_array_ref):
+                        parse_and_add(sofa_byte_array_ref, json_feature_structures.get(sofa_byte_array_ref))
                     fs_id = int(fs_id)
                     fs = self._parse_sofa(cas, fs_id, json_fs, feature_structures)
                     feature_structures[fs.xmiID] = fs
             for fs_id, json_fs in json_feature_structures.items():
                 if json_fs.get(TYPE_FIELD) != TYPE_NAME_SOFA:
-                    fs_id = int(fs_id)
-                    fs = self._parse_feature_structure(typesystem, fs_id, json_fs, feature_structures)
-                    feature_structures[fs.xmiID] = fs
+                    parse_and_add(fs_id, json_fs)
 
         for post_processor in self._post_processors:
             post_processor()

--- a/tests/test_files/json/fs_as_array/one-way/casWithBadSofaFsOrder/data-ref.json
+++ b/tests/test_files/json/fs_as_array/one-way/casWithBadSofaFsOrder/data-ref.json
@@ -1,0 +1,37 @@
+{
+  "%FEATURE_STRUCTURES": [
+    {
+      "%ID": 2,
+      "%TYPE": "uima.cas.Sofa",
+      "mimeType": "text",
+      "sofaID": "_InitialView",
+      "sofaNum": 1,
+      "sofaString": "This is a test ."
+    },
+    {
+      "%ID": 1,
+      "%TYPE": "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+      "@sofa": 2,
+      "begin": 0,
+      "end": 4
+    }
+  ],
+  "%TYPES": {
+    "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token": {
+      "%NAME": "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+      "%SUPER_TYPE": "uima.tcas.Annotation",
+      "parent": {
+        "%NAME": "parent",
+        "%RANGE": "uima.tcas.Annotation"
+      }
+    }
+  },
+  "%VIEWS": {
+    "_InitialView": {
+      "%MEMBERS": [
+        1
+      ],
+      "%SOFA": 2
+    }
+  }
+}

--- a/tests/test_files/json/fs_as_array/one-way/casWithBadSofaFsOrder/data.json
+++ b/tests/test_files/json/fs_as_array/one-way/casWithBadSofaFsOrder/data.json
@@ -1,0 +1,32 @@
+{
+  "%TYPES" : {
+    "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token" : {
+      "%NAME" : "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+      "%SUPER_TYPE" : "uima.tcas.Annotation",
+      "parent" : {
+        "%NAME" : "parent",
+        "%RANGE" : "uima.tcas.Annotation"
+      }
+    }
+  },
+  "%FEATURE_STRUCTURES" : [ {
+    "%ID" : 1,
+    "%TYPE" : "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+    "@sofa" : 2,
+    "begin" : 0,
+    "end" : 4
+  }, {
+    "%ID" : 2,
+    "%TYPE" : "uima.cas.Sofa",
+    "sofaNum" : 1,
+    "sofaID" : "_InitialView",
+    "mimeType" : "text",
+    "sofaString" : "This is a test ."
+  } ],
+  "%VIEWS" : {
+    "_InitialView" : {
+      "%SOFA" : 2,
+      "%MEMBERS" : [ 1 ]
+    }
+  }
+}

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -7,8 +7,9 @@ from tests.util import assert_json_equal
 
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_files", "json")
 SER_REF_DIR = os.path.join(FIXTURE_DIR, "fs_as_array", "ser-ref")
+ONE_WAY_DIR = os.path.join(FIXTURE_DIR, "fs_as_array", "one-way")
 
-FIXTURES = [
+ROUND_TRIP_FIXTURES = [
     (os.path.join(SER_REF_DIR, "casWithSofaDataArray"), []),
     (os.path.join(SER_REF_DIR, "casWithSofaDataURI"), []),
     (os.path.join(SER_REF_DIR, "casWithFloatingPointSpecialValues"), []),
@@ -80,16 +81,35 @@ FIXTURES = [
     (
         os.path.join(SER_REF_DIR, "casExtendingDocumentAnnotation"),
         [["de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData", 0, 16, "This is a test ."]],
-    ),
+    )
 ]
 
+ONE_WAY_FIXTURES = [
+    (
+        os.path.join(ONE_WAY_DIR, "casWithBadSofaFsOrder"),
+        [["de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData", 0, 16, "This is a test ."]],
+    )
+]
 
-@pytest.mark.parametrize("json_path, annotations", FIXTURES)
+@pytest.mark.parametrize("json_path, annotations", ROUND_TRIP_FIXTURES)
 def test_deserialization_serialization(json_path, annotations):
     with open(os.path.join(json_path, "data.json"), "rb") as f:
         cas = load_cas_from_json(f)
 
     with open(os.path.join(json_path, "data.json"), "rb") as f:
+        expected_json = json.load(f)
+
+    actual_json = cas.to_json(pretty_print=True)
+
+    assert_json_equal(actual_json, expected_json, sort_keys=True)
+
+
+@pytest.mark.parametrize("json_path, annotations", ONE_WAY_FIXTURES)
+def test_deserialization_serialization_one_way(json_path, annotations):
+    with open(os.path.join(json_path, "data.json"), "rb") as f:
+        cas = load_cas_from_json(f)
+
+    with open(os.path.join(json_path, "data-ref.json"), "rb") as f:
         expected_json = json.load(f)
 
     actual_json = cas.to_json(pretty_print=True)
@@ -128,7 +148,7 @@ def test_multi_feature_random_serialization_deserialization():
         assert_json_equal(actual_json, expected_json)
 
 
-@pytest.mark.parametrize("json_path, annotations", FIXTURES)
+@pytest.mark.parametrize("json_path, annotations", ROUND_TRIP_FIXTURES)
 def test_unicode(json_path, annotations):
     with open(os.path.join(json_path, "data.json"), "rb") as f:
         cas = load_cas_from_json(f)


### PR DESCRIPTION
- Fix issue by iterating twice over the FS list, once for Sofas and once for other FSes
- Added test case