### PR TITLE
#290 - Speedup load_cas_from_xmi by improving offset mapping

### DIFF
--- a/cassis/xmi.py
+++ b/cassis/xmi.py
@@ -295,7 +295,9 @@ class CasXmiDeserializer:
             else:
                 view = cas.create_view(sofa.sofaID, xmiID=sofa.xmiID, sofaNum=sofa.sofaNum)
 
-            view.sofa_string = sofa.sofaString
+            # Directly set the sofaString and offsetConverter for the sofa to avoid recomputing the offset convertion (slow!) when using the setter
+            view.get_sofa()._sofaString = sofa.sofaString
+            view.get_sofa()._offset_converter = sofa._offset_converter
             view.sofa_mime = sofa.mimeType
 
             # If a sofa has no members, then UIMA might omit the view. In that case,


### PR DESCRIPTION
1. Added an LRU Cache for speeding up the `encode` function and refactored the `create_offset_mapping`
2. When reading a CAS-XMI, directly pass down the offset mappings to avoid recomputing them.

Reduced the time spent in `create_offset_mapping` from 49% to 8%.