### PR TITLE
Issue #293: Relaxed dependency on attrs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ REQUIRES_PYTHON = ">=3.7.0"
 
 install_requires = [
     "lxml~=4.9.1",
-    "attrs==21.2.*",
+    "attrs>=21.2,<24",
     "sortedcontainers==2.4.*",
     "toposort==1.7",
     "more-itertools==8.12.*",


### PR DESCRIPTION
- Relaxed constraint on `attrs`
- Tested manually with `attrs==22.2.0`, and automatically with newest version `23.1.0`