### PR TITLE
#299 - cassis won't find tokens when doing cas.select(...TOP)

### DIFF
--- a/cassis/typesystem.py
+++ b/cassis/typesystem.py
@@ -866,7 +866,7 @@ class TypeSystem:
         supertype = self.get_type(supertypeName)
         new_type = Type(name=name, supertype=supertype, description=description, typesystem=self)
 
-        if supertypeName != TOP_TYPE_NAME:
+        if name != TOP_TYPE_NAME:
             supertype._children[name] = new_type
 
             for feature in supertype.all_features:

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -125,6 +125,7 @@ def test_select(small_typesystem_xml, tokens, sentences):
     assert list(cas.select("cassis.Sentence")) == sentences
     assert list(cas.select(ts.get_type("cassis.Token"))) == tokens
     assert list(cas.select(ts.get_type("cassis.Sentence"))) == sentences
+    assert set(cas.select(ts.get_type(TYPE_NAME_TOP))) == set(tokens) | set(sentences)
 
 
 def test_select_also_returns_parent_instances(small_typesystem_xml, tokens, sentences):


### PR DESCRIPTION
- Fix problem that the TOP type never gets any child types assigned despite it being the root type
- Added unit test