### PR TITLE
#312 - Ability to retrieve a type by its short name

### DIFF
--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -143,7 +143,9 @@ def test_select(small_typesystem_xml, tokens, sentences):
     cas = Cas(typesystem=ts)
     cas.add_all(tokens + sentences)
 
+    assert list(cas.select("Token")) == tokens
     assert list(cas.select("cassis.Token")) == tokens
+    assert list(cas.select("Sentence")) == sentences
     assert list(cas.select("cassis.Sentence")) == sentences
     assert list(cas.select(ts.get_type("cassis.Token"))) == tokens
     assert list(cas.select(ts.get_type("cassis.Sentence"))) == sentences

--- a/tests/test_typesystem.py
+++ b/tests/test_typesystem.py
@@ -515,8 +515,17 @@ def test_type_name():
     cas = Cas()
 
     Annotation = cas.typesystem.get_type(TYPE_NAME_ANNOTATION)
+    assert cas.typesystem.contains_type(TYPE_NAME_ANNOTATION)
     assert Annotation.name == TYPE_NAME_ANNOTATION
     assert Annotation.short_name == "Annotation"
+
+
+def test_get_type_by_short_name():
+    cas = Cas()
+
+    Annotation = cas.typesystem.get_type("Annotation")
+    assert cas.typesystem.contains_type("Annotation")
+    assert Annotation.name == TYPE_NAME_ANNOTATION
 
 
 def test_get_types():


### PR DESCRIPTION
**What's in the PR**
- Changed get_type and contains_type to be able to handle non-ambiguous short names

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
